### PR TITLE
Add simple Flask inventory web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+inventory.db
+*.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Inventory App
+
+Aplicación web simple para gestionar inventario usando Flask y SQLite.
+
+## Requisitos
+
+- Python 3
+- Dependencias en `requirements.txt`
+
+## Cómo ejecutar
+
+1. Instala las dependencias:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Inicia el servidor:
+
+   ```bash
+   python app.py
+   ```
+
+3. Desde tu celular, abre un navegador y visita `http://<ip-del-servidor>:5000/`, reemplazando `<ip-del-servidor>` con la dirección IP de la computadora que ejecuta el servidor.
+
+## Pruebas
+
+Ejecuta las pruebas con:
+
+```bash
+pytest
+```
+
+## Funcionalidad
+
+- Agregar artículos con cantidad.
+- Actualizar cantidades.
+- Eliminar artículos.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+from flask import Flask, render_template, request, redirect, url_for
+import sqlite3
+from pathlib import Path
+
+app = Flask(__name__)
+DB_PATH = Path("inventory.db")
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            quantity INTEGER NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+@app.route('/')
+def index():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute('SELECT * FROM items ORDER BY name')
+    items = cur.fetchall()
+    conn.close()
+    return render_template('index.html', items=items)
+
+@app.route('/add', methods=['POST'])
+def add_item():
+    name = request.form['name']
+    quantity = int(request.form['quantity'])
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    try:
+        cur.execute('INSERT INTO items (name, quantity) VALUES (?, ?)', (name, quantity))
+        conn.commit()
+    except sqlite3.IntegrityError:
+        cur.execute('UPDATE items SET quantity = quantity + ? WHERE name = ?', (quantity, name))
+        conn.commit()
+    finally:
+        conn.close()
+    return redirect(url_for('index'))
+
+@app.route('/update/<int:item_id>', methods=['POST'])
+def update_item(item_id):
+    quantity = int(request.form['quantity'])
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('UPDATE items SET quantity = ? WHERE id = ?', (quantity, item_id))
+    conn.commit()
+    conn.close()
+    return redirect(url_for('index'))
+
+@app.route('/delete/<int:item_id>', methods=['POST'])
+def delete_item(item_id):
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('DELETE FROM items WHERE id = ?', (item_id,))
+    conn.commit()
+    conn.close()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    init_db()
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Inventario</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 1rem; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 0.5rem; border: 1px solid #ccc; text-align: left; }
+        form { margin: 0; }
+        input[type=text], input[type=number] { width: 100%; box-sizing: border-box; padding: 0.25rem; }
+        .actions { display: flex; gap: 0.25rem; }
+    </style>
+</head>
+<body>
+    <h1>Inventario</h1>
+    <h2>Agregar artículo</h2>
+    <form action="{{ url_for('add_item') }}" method="post">
+        <input type="text" name="name" placeholder="Nombre" required>
+        <input type="number" name="quantity" placeholder="Cantidad" min="0" required>
+        <button type="submit">Agregar</button>
+    </form>
+    <h2>Artículos</h2>
+    <table>
+        <thead>
+            <tr><th>Nombre</th><th>Cantidad</th><th>Acciones</th></tr>
+        </thead>
+        <tbody>
+        {% for item in items %}
+            <tr>
+                <td>{{ item['name'] }}</td>
+                <td>
+                    <form action="{{ url_for('update_item', item_id=item['id']) }}" method="post">
+                        <input type="number" name="quantity" value="{{ item['quantity'] }}" min="0" required>
+                        <button type="submit">Actualizar</button>
+                    </form>
+                </td>
+                <td class="actions">
+                    <form action="{{ url_for('delete_item', item_id=item['id']) }}" method="post">
+                        <button type="submit">Eliminar</button>
+                    </form>
+                </td>
+            </tr>
+        {% else %}
+            <tr><td colspan="3">Sin artículos</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import app as flask_app
+
+
+@pytest.fixture(autouse=True)
+def setup(tmp_path):
+    flask_app.DB_PATH = tmp_path / "test.db"
+    flask_app.init_db()
+    yield
+
+
+def get_items(client):
+    response = client.get('/')
+    return response.data.decode('utf-8')
+
+
+def test_add_item():
+    client = flask_app.app.test_client()
+    client.post('/add', data={'name': 'manzana', 'quantity': '5'})
+    page = get_items(client)
+    assert 'manzana' in page
+    assert '5' in page
+
+
+def test_update_and_delete_item():
+    client = flask_app.app.test_client()
+    client.post('/add', data={'name': 'pera', 'quantity': '3'})
+    # update
+    with flask_app.sqlite3.connect(flask_app.DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute('SELECT id FROM items WHERE name = ?', ('pera',))
+        item_id = cur.fetchone()[0]
+    client.post(f'/update/{item_id}', data={'quantity': '10'})
+    page = get_items(client)
+    assert '10' in page
+    # delete
+    client.post(f'/delete/{item_id}')
+    page = get_items(client)
+    assert 'pera' not in page


### PR DESCRIPTION
## Summary
- build Flask + SQLite inventory app with routes to list, add, update, and delete items
- create mobile-friendly HTML interface for managing inventory
- add pytest suite verifying CRUD operations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689404fab7408326bee498891e0150a0